### PR TITLE
use latest productised image

### DIFF
--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -1,5 +1,5 @@
-prometheus_image: "docker.io/prom/prometheus"
-prometheus_version: "v2.0.0"
+prometheus_image: "registry.access.redhat.com/openshift3/prometheus"
+prometheus_version: "latest"
 prometheus_port: 9090
 prometheus_configmap_name: "prometheus-configmap"
 prometheus_configmap_volume_name: "prometheus-configmap-volume"


### PR DESCRIPTION
The prometheus image we are using in the metrics-apb should be the official productised Red Hat image. 

This PR changes the image in the apb to the latest official image.