### PR TITLE
fix: create a ReadWriteMany PVC for Grafana

### DIFF
--- a/roles/provision-metrics-apb/tasks/main.yml
+++ b/roles/provision-metrics-apb/tasks/main.yml
@@ -53,7 +53,7 @@
       app: grafana
       service: prometheus
     access_modes:
-      - ReadWriteOnce
+      - ReadWriteMany
     resources_requests:
       storage: "{{ GRAFANA_STORAGE_SIZE }}Gi"
     state: present


### PR DESCRIPTION
Just a tiny thing I missed in https://github.com/aerogearcatalog/metrics-apb/pull/7

This is necessary to allow scaling of the Grafana pods