### PR TITLE
More unique name for the OpenShift project name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 @Library('fh-pipeline-library') _
 
 def repositoryName = "metrics-apb"
-def projectName = "test-${repositoryName}-${currentBuild.number}"
+def projectName = "test-${repositoryName}-${currentBuild.startTimeInMillis}"
 
 stage('Trust') {
     enforceTrustedApproval('aerogear')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 @Library('fh-pipeline-library') _
 
 def repositoryName = "metrics-apb"
-def projectName = "test-${repositoryName}-${currentBuild.startTimeInMillis}"
+def projectName = "test-${repositoryName}-${currentBuild.number}-${currentBuild.startTimeInMillis}"
 
 stage('Trust') {
     enforceTrustedApproval('aerogear')


### PR DESCRIPTION
@grdryn based on your suggestion from previous PR

I was also discussing with @AdamSaleh that maybe we could add the name of the branch to the project name, but this would be quite risky, because OpenShift project names may only contain lower-case letters, numbers, and dashes. So we would need another function to check that.

wdyt