### PR TITLE
Grafana Auto Dashboards

### DIFF
--- a/roles/deprovision-metrics-apb/tasks/main.yml
+++ b/roles/deprovision-metrics-apb/tasks/main.yml
@@ -29,6 +29,11 @@
     namespace: '{{ namespace }}'
     state: absent
 
+- k8s_v1_config_map:
+    name: grafana-dashboards-providers-configmap
+    namespace: '{{ namespace }}'
+    state: absent
+
 - k8s_v1_service_account:
     name: oauth-proxy
     namespace: '{{ namespace }}'

--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -10,6 +10,8 @@ grafana_image: "docker.io/grafana/grafana"
 # TODO: Change to 4.7.0 when a tag is available
 grafana_version: "master"
 grafana_port: 3000
+# Either "debug", "info", "warn", "error", "critical", default is "info"
+grafana_log_level: info
 grafana_ini_configmap_name: "grafana-ini-configmap"
 grafana_ini_configmap_volume_name: "grafana-ini-configmap-volume"
 grafana_datasources_configmap_name: "grafana-datasources-configmap"

--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -8,12 +8,14 @@ prometheus_proxy_port: 4180
 # Grafana values
 grafana_image: "docker.io/grafana/grafana"
 # TODO: Change to 4.7.0 when a tag is available
-grafana_version: "latest"
+grafana_version: "master"
 grafana_port: 3000
 grafana_ini_configmap_name: "grafana-ini-configmap"
 grafana_ini_configmap_volume_name: "grafana-ini-configmap-volume"
 grafana_datasources_configmap_name: "grafana-datasources-configmap"
 grafana_datasources_configmap_volume_name: "grafana-datasources-configmap-volume"
+grafana_dashboards_providers_configmap_name: "grafana-dashboards-providers-configmap"
+grafana_dashboards_providers_configmap_volume_name: "grafana-dashboards-providers-configmap-volume"
 grafana_dashboards_configmap_name: "grafana-dashboards-configmap"
 grafana_dashboards_configmap_volume_name: "grafana-dashboards-configmap-volume"
 grafana_proxy_port: 4181

--- a/roles/provision-metrics-apb/files/grafana-dashboards-provider.yml
+++ b/roles/provision-metrics-apb/files/grafana-dashboards-provider.yml
@@ -1,0 +1,6 @@
+- name: 'default'
+  org_id: 1
+  folder: ''
+  type: file
+  options:
+    folder: /etc/grafana-dashboards

--- a/roles/provision-metrics-apb/files/grafana-dashboards-provider.yml
+++ b/roles/provision-metrics-apb/files/grafana-dashboards-provider.yml
@@ -3,4 +3,4 @@
   folder: ''
   type: file
   options:
-    folder: /etc/grafana-dashboards
+    path: /etc/grafana-dashboards

--- a/roles/provision-metrics-apb/files/grafana-fh-sync-dashboard.json
+++ b/roles/provision-metrics-apb/files/grafana-fh-sync-dashboard.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": false,
-  "id": 3,
+  "id": null,
   "links": [],
   "refresh": "5s",
   "rows": [

--- a/roles/provision-metrics-apb/files/grafana-primary-dashboard.json
+++ b/roles/provision-metrics-apb/files/grafana-primary-dashboard.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": false,
-  "id": 2,
+  "id": null,
   "links": [],
   "refresh": "5s",
   "rows": [

--- a/roles/provision-metrics-apb/tasks/main.yml
+++ b/roles/provision-metrics-apb/tasks/main.yml
@@ -25,6 +25,9 @@
 - name: Create config-map from datasources config
   shell: oc create configmap '{{ grafana_datasources_configmap_name }}' --from-file=datasources.yml=/tmp/datasources.yml -n '{{ namespace }}'
 
+- name: Create config-map from dashboards provider config
+  shell: oc create configmap '{{ grafana_dashboards_providers_configmap_name }}' --from-file=provider.yml={{ role_path }}/files/grafana-dashboards-provider.yml -n '{{ namespace }}'
+
 - name: Create config-map from dashboards config
   shell: >
     oc create configmap '{{ grafana_dashboards_configmap_name }}' \
@@ -162,8 +165,10 @@
       volume_mounts:
         - mount_path: /etc/grafana
           name: '{{ grafana_ini_configmap_volume_name }}'
-        - mount_path: /etc/grafana-datasources
+        - mount_path: /etc/grafana/conf/provisioning/datasources
           name: '{{ grafana_datasources_configmap_volume_name }}'
+        - mount_path: /etc/grafana/conf/provisioning/dashboards
+          name: '{{ grafana_dashboards_providers_configmap_volume_name }}'
         - mount_path: /etc/grafana-dashboards
           name: '{{ grafana_dashboards_configmap_volume_name }}'
         - mount_path: /var/lib/grafana
@@ -183,6 +188,10 @@
         config_map:
           defaultMode: 420
           name: '{{ grafana_dashboards_configmap_name }}'
+      - name: '{{ grafana_dashboards_providers_configmap_volume_name }}'
+        config_map:
+          defaultMode: 420
+          name: '{{ grafana_dashboards_providers_configmap_name }}'
       - name: grafana-data
         persistent_volume_claim:
           claim_name: grafana-claim

--- a/roles/provision-metrics-apb/templates/grafana-config-map.ini.j2
+++ b/roles/provision-metrics-apb/templates/grafana-config-map.ini.j2
@@ -2,11 +2,11 @@
 data = /var/lib/grafana
 logs = /var/log/grafana
 plugins = /var/lib/grafana/plugins
-datasources = /etc/grafana-datasources
+provisioning = /etc/grafana/conf/provisioning
 
 [dashboards.json]
-enabled = true
-path = /etc/grafana-dashboards
+# enabled = true
+# path = /etc/grafana-dashboards
 
 [log]
 # Either "console", "file", "syslog". Default is console and  file
@@ -42,3 +42,8 @@ auto_assign_org = true
 
 # The role new users will be assigned for the main organization (if the above setting is set to true). Defaults to Viewer, other valid options are Admin and Editor and Read Only Editor. e.g. :
 auto_assign_org_role = Admin
+
+[log]
+
+# Either "debug", "info", "warn", "error", "critical", default is "info"
+level = debug

--- a/roles/provision-metrics-apb/templates/grafana-config-map.ini.j2
+++ b/roles/provision-metrics-apb/templates/grafana-config-map.ini.j2
@@ -46,4 +46,4 @@ auto_assign_org_role = Admin
 [log]
 
 # Either "debug", "info", "warn", "error", "critical", default is "info"
-level = debug
+level = {{ grafana_log_level }}

--- a/roles/provision-metrics-apb/templates/grafana-config-map.ini.j2
+++ b/roles/provision-metrics-apb/templates/grafana-config-map.ini.j2
@@ -4,10 +4,6 @@ logs = /var/log/grafana
 plugins = /var/lib/grafana/plugins
 provisioning = /etc/grafana/conf/provisioning
 
-[dashboards.json]
-# enabled = true
-# path = /etc/grafana-dashboards
-
 [log]
 # Either "console", "file", "syslog". Default is console and  file
 # Use space to separate multiple modes, e.g. "console file"


### PR DESCRIPTION
This PR implements Grafana Auto Dashboard Discovery. The description of how this works comes straight from the [metrics proposal](https://github.com/aerogear/proposals/blob/master/metrics/prometheus-metrics-endpoints-and-auto-discovery.md#metrics-service):

The 5.x stream of Grafana has the ability to load dashboards from disk and update the dashboards when the files on disk are also updated. This is possible using something called a provider. A provider is a configuration item that tells Grafana how and where to load dashboards. The idea is in the future Grafana may have different providers for loading dashboards from disk, source control, via an API, etc.

In the grafana `.ini` file, a provisioning path is configured:

```ini
provisioning = /etc/grafana/conf/provisioning
```

The `provisioning` directory contains two subdirectories:

* `datasources` - A directory with datasource definition files.
* `dashboards` - A directory with dashboard providers. (Not the actual dashboard definitions)

In the `dashboards` directory we will have a provider that looks like this:

```yaml
- name: 'default'
  org_id: 1
  folder: ''
  type: file
  options:
    path: /etc/grafana-dashboards
```

This file instructs Grafana to search for dashboard definitions in `/etc/grafana-dashboards`. Dashboard files can be inserted and modified at any time and the changes will be reflected in Grafana.

This approach allows us to load the datasources, dashboard providers and dashboard definitions using Config Maps. Dashboard definitions for individual mobile enabled services can be defined in their respective APBs. As part of the provision, the APB can append or update the dashboard in the dashboards Config Map.

## How to Test

Provision the metrics-apb using the changes included in this branch. 2 things you should notice instantly when Grafana comes up:

1. The prometheus datasource is automatically configured
2. Under `Manage > Dashboards` you will see two dashboards. An fh-sync-server dashboard and a 'Primary Dashboard'.

The two dashboards were loaded in from the `grafana-dashboards-configmap` config map. The easiest way to check that discovery works is by finding that config map and selecting the **Edit** feature. This brings up a key-value pair editor. Add a new key value pair, name it `<something>.json` and paste in the following:

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "gnetId": null,
  "graphTooltip": 0,
  "id": null,
  "links": [],
  "panels": [
    {
      "aliasColors": {},
      "bars": false,
      "dashLength": 10,
      "dashes": false,
      "datasource": null,
      "fill": 1,
      "gridPos": {
        "h": 9,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "legend": {
        "avg": false,
        "current": false,
        "max": false,
        "min": false,
        "show": true,
        "total": false,
        "values": false
      },
      "lines": true,
      "linewidth": 1,
      "links": [],
      "nullPointMode": "null",
      "percentage": false,
      "pointradius": 5,
      "points": false,
      "renderer": "flot",
      "seriesOverrides": [],
      "spaceLength": 10,
      "stack": false,
      "steppedLine": false,
      "targets": [
        {
          "expr": "",
          "format": "time_series",
          "intervalFactor": 1,
          "refId": "A"
        }
      ],
      "thresholds": [],
      "timeFrom": null,
      "timeShift": null,
      "title": "Dashboard Discovery is Great!",
      "tooltip": {
        "shared": true,
        "sort": 0,
        "value_type": "individual"
      },
      "type": "graph",
      "xaxis": {
        "buckets": null,
        "mode": "time",
        "name": null,
        "show": true,
        "values": []
      },
      "yaxes": [
        {
          "format": "short",
          "label": null,
          "logBase": 1,
          "max": null,
          "min": null,
          "show": true
        },
        {
          "format": "short",
          "label": null,
          "logBase": 1,
          "max": null,
          "min": null,
          "show": true
        }
      ]
    }
  ],
  "schemaVersion": 16,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {
    "refresh_intervals": [
      "5s",
      "10s",
      "30s",
      "1m",
      "5m",
      "15m",
      "30m",
      "1h",
      "2h",
      "1d"
    ],
    "time_options": [
      "5m",
      "15m",
      "1h",
      "6h",
      "12h",
      "24h",
      "2d",
      "7d",
      "30d"
    ]
  },
  "timezone": "",
  "title": "I've Been Discovered!",
  "version": 1
}
```

Once the Config Map has been saved go back to Grafana, wait a couple of seconds and Refresh. You should eventually see the new dashboard appear.

You can also test that changes to the dahsboards will be reflected. Try editing some labels or panel titles in the dashboard JSON in the config map and refreshing. **Note that changing the dashboard title will cause a new dashboard to be created.** This is a known bug in Grafana which is currently being fixed

