### PR TITLE
use aerogearcatalog custom Grafana image

### DIFF
--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -3,7 +3,7 @@ prometheus_version: "latest"
 prometheus_port: 9090
 prometheus_proxy_port: 4180
 # Grafana values
-grafana_image: "docker.io/aerogear/grafana"
+grafana_image: "docker.io/aerogearcatalog/grafana"
 # TODO: Change to 4.7.0 when a tag is available
 grafana_version: "latest"
 grafana_port: 3000

--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -3,12 +3,12 @@ prometheus_version: "latest"
 prometheus_port: 9090
 prometheus_proxy_port: 4180
 # Grafana values
-grafana_image: "docker.io/grafana/grafana"
+grafana_image: "docker.io/aerogear/grafana"
 # TODO: Change to 4.7.0 when a tag is available
-grafana_version: "master"
+grafana_version: "latest"
 grafana_port: 3000
 grafana_proxy_port: 4181
-grafana_log_level: info
+grafana_log_level: debug
 # OAuth Proxy values
 proxy_image: "docker.io/openshift/oauth-proxy"
 proxy_version: "v1.1.0"

--- a/roles/provision-metrics-apb/files/grafana-dashboards-provider.yml
+++ b/roles/provision-metrics-apb/files/grafana-dashboards-provider.yml
@@ -3,4 +3,4 @@
   folder: ''
   type: file
   options:
-    path: /etc/grafana-dashboards
+    folder: /etc/grafana-dashboards

--- a/roles/provision-metrics-apb/tasks/main.yml
+++ b/roles/provision-metrics-apb/tasks/main.yml
@@ -153,8 +153,6 @@
       - --cookie-secret=SECRET
     - name: grafana
       image: '{{ grafana_image }}:{{ grafana_version }}'
-      env:
-        - GF_INSTALL_PLUGINS='grafana-piechart-panel,grafana-worldmap-panel'
       ports:
       - container_port: '{{ grafana_port }}'
         protocol: TCP

--- a/roles/provision-metrics-apb/tasks/main.yml
+++ b/roles/provision-metrics-apb/tasks/main.yml
@@ -153,6 +153,8 @@
       - --cookie-secret=SECRET
     - name: grafana
       image: '{{ grafana_image }}:{{ grafana_version }}'
+      env:
+        - GF_INSTALL_PLUGINS='grafana-piechart-panel,grafana-worldmap-panel'
       ports:
       - container_port: '{{ grafana_port }}'
         protocol: TCP

--- a/roles/provision-metrics-apb/tasks/main.yml
+++ b/roles/provision-metrics-apb/tasks/main.yml
@@ -151,14 +151,8 @@
       - --http-address=0.0.0.0:{{ grafana_proxy_port }}
       - --https-address=
       - --cookie-secret=SECRET
-    - env:
+    - name: grafana
       image: '{{ grafana_image }}:{{ grafana_version }}'
-      command:
-        - /usr/sbin/grafana-server
-      args:
-        - '--homepath=/usr/share/grafana'
-        - '--config=/etc/grafana/grafana.ini'
-      name: grafana
       ports:
       - container_port: '{{ grafana_port }}'
         protocol: TCP


### PR DESCRIPTION
## Description

Myself and @StevenTobin have built a custom Grafana image based off the Grafana master branch at a certain point in time. The image also has the [pie chart panel](https://grafana.com/plugins/grafana-piechart-panel) and [worldmap panel](https://grafana.com/plugins/grafana-worldmap-panel) plugins baked in baked in by default.

It's been pushed to https://hub.docker.com/r/aerogearcatalog/grafana/. This PR switches us over to using that image. (also minor side note: it also enables debug logging in Grafana by default)

## Why?

* We're using features that are only available on the master branch of Grafana. These features will become GA with the Grafana 5.0 release in the next few months. Right now the problem is the master branch is pretty unstable. We've run into a couple of issues where dashboard and datasource discovery stopped working. The custom image will help us avoid these kinds of issues by locking us down to a commit that is known to be pretty stable.

* We currently have issues where we cannot install any plugins into Grafana running in OpenShift. We haven't worked out a good solution yet but we need something in place because the keycloak dashboard depends on plugins. See the discussion at https://github.com/aerogearcatalog/keycloak-apb/pull/33#pullrequestreview-93935750 to better understand the plugins issue. 

The approach of baking the plugins is not the best. We tried an approach where the plugins would be installed at startup time using an environment variable but there were issues where Grafana wouldn't start up as a result. We think this may be a bug in Grafana itself. However, this should keep us going for the time being as we figure out a better solution.

cc @david-martin 

Edit: I forgot to mention, we made a fork of the grafana build tools repo here: https://github.com/aerogear/grafana-docker

This was the repo used to build and push the docker image to dockerhub.