### PR TITLE
Adds test checks for config-maps and secret

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ node ('apb-test') {
                     podSelector = openshift.selector("pod", "testing-pod")
                     
                     try {
-                        timeout(5) {
+                        timeout(10) {
                             podSelector.untilEach(1) {
                                 podPhase = it.object().status.phase
                                 println("Pod status:" + podPhase)

--- a/roles/test-provision-apb/tasks/main.yml
+++ b/roles/test-provision-apb/tasks/main.yml
@@ -27,9 +27,9 @@
   until: '"Log in with OpenShift" in webpage.content'
 
 - name: Get Grafana dashboards configmap
-  shell: "oc get configmap -o name | grep {{ grafana-dashboards-configmap-name }}"
+  shell: "oc get configmap -o name | grep {{ grafana_dashboards_configmap_name }}"
   register: grafana_dashboards_configmap
-  failed_when: '"{{ grafana-dashboards-configmap-name }}" not in grafana_dashboards_configmap.stdout'
+  failed_when: '"{{ grafana_dashboards_configmap_name }}" not in grafana_dashboards_configmap.stdout'
 
 - name: Get Grafana dashboards providers configmap
   shell: "oc get configmap -o name | grep {{ grafana_dashboards_providers_configmap_name }}"

--- a/roles/test-provision-apb/tasks/main.yml
+++ b/roles/test-provision-apb/tasks/main.yml
@@ -25,3 +25,33 @@
     - webpage.status == 403
     - '"Log in with OpenShift" not in webpage.content'
   until: '"Log in with OpenShift" in webpage.content'
+
+- name: Get Grafana dashboards configmap
+  shell: "oc get configmap -o name | grep {{ grafana-dashboards-configmap-name }}"
+  register: grafana_dashboards_configmap
+  failed_when: '"{{ grafana-dashboards-configmap-name }}" not in grafana_dashboards_configmap.stdout'
+
+- name: Get Grafana dashboards providers configmap
+  shell: "oc get configmap -o name | grep {{ grafana_dashboards_providers_configmap_name }}"
+  register: grafana_dashboards_providers_configmap
+  failed_when: '"{{ grafana_dashboards_providers_configmap_name }}" not in grafana_dashboards_providers_configmap.stdout'
+
+- name: Get Grafana datasources configmap
+  shell: "oc get configmap -o name | grep {{ grafana_datasources_configmap_name }}"
+  register: grafana_datasources_configmap
+  failed_when: '"{{ grafana_datasources_configmap_name }}" not in grafana_datasources_configmap.stdout'
+
+- name: Get Grafana ini configmap
+  shell: "oc get configmap -o name | grep {{ grafana_ini_configmap_name }}"
+  register: grafana_ini_configmap
+  failed_when: '"{{ grafana_ini_configmap_name }}" not in grafana_ini_configmap.stdout'
+
+- name: Get Prometheus configmap
+  shell: "oc get configmap -o name | grep {{ prometheus_configmap_name }}"
+  register: prometheus_configmap
+  failed_when: '"{{ prometheus_configmap_name }}" not in prometheus_configmap.stdout'
+
+- name: Check that metrics secret exists
+  shell: "oc get secrets -o name | grep {{ prometheus_secret_name }}"
+  register: metrics_secret
+  failed_when: '"{{ prometheus_secret_name }}" not in metrics_secret.stdout'


### PR DESCRIPTION
### Description
This PR adds some checks in the current test-provision role. It makes sure the following config maps are present:

- grafana-dashboards-configmap
- grafana-dashboards-providers-configmap
- grafana-datasources-configmap
- grafana-ini-configmap
- prometheus-configmap

And the following secret:
- prometheus_secret
