### PR TITLE
Fixed jinja2 warnings

### DIFF
--- a/roles/test-provision-apb/tasks/main.yml
+++ b/roles/test-provision-apb/tasks/main.yml
@@ -29,29 +29,29 @@
 - name: Get Grafana dashboards configmap
   shell: "oc get configmap -o name | grep {{ grafana_dashboards_configmap_name }}"
   register: grafana_dashboards_configmap
-  failed_when: '"{{ grafana_dashboards_configmap_name }}" not in grafana_dashboards_configmap.stdout'
+  failed_when: grafana_dashboards_configmap_name not in grafana_dashboards_configmap.stdout
 
 - name: Get Grafana dashboards providers configmap
   shell: "oc get configmap -o name | grep {{ grafana_dashboards_providers_configmap_name }}"
   register: grafana_dashboards_providers_configmap
-  failed_when: '"{{ grafana_dashboards_providers_configmap_name }}" not in grafana_dashboards_providers_configmap.stdout'
+  failed_when: grafana_dashboards_providers_configmap_name not in grafana_dashboards_providers_configmap.stdout
 
 - name: Get Grafana datasources configmap
   shell: "oc get configmap -o name | grep {{ grafana_datasources_configmap_name }}"
   register: grafana_datasources_configmap
-  failed_when: '"{{ grafana_datasources_configmap_name }}" not in grafana_datasources_configmap.stdout'
+  failed_when: grafana_datasources_configmap_name not in grafana_datasources_configmap.stdout
 
 - name: Get Grafana ini configmap
   shell: "oc get configmap -o name | grep {{ grafana_ini_configmap_name }}"
   register: grafana_ini_configmap
-  failed_when: '"{{ grafana_ini_configmap_name }}" not in grafana_ini_configmap.stdout'
+  failed_when: grafana_ini_configmap_name not in grafana_ini_configmap.stdout
 
 - name: Get Prometheus configmap
   shell: "oc get configmap -o name | grep {{ prometheus_configmap_name }}"
   register: prometheus_configmap
-  failed_when: '"{{ prometheus_configmap_name }}" not in prometheus_configmap.stdout'
+  failed_when: prometheus_configmap_name not in prometheus_configmap.stdout
 
 - name: Check that metrics secret exists
   shell: "oc get secrets -o name | grep {{ prometheus_secret_name }}"
   register: metrics_secret
-  failed_when: '"{{ prometheus_secret_name }}" not in metrics_secret.stdout'
+  failed_when: prometheus_secret_name not in metrics_secret.stdout


### PR DESCRIPTION
Fixes this kind of warning:
```
[logs:pod/testing-pod] TASK [test-provision-apb : Get Grafana dashboards configmap] *******************
[logs:pod/testing-pod]  [WARNING]: when statements should not include jinja2 templating delimiters
[logs:pod/testing-pod] such as {{ }} or {% %}. Found: "{{ grafana_dashboards_configmap_name }}" not in
[logs:pod/testing-pod] grafana_dashboards_configmap.stdout
```
Reference: https://github.com/ansible/ansible/issues/22397