### PR TITLE
AEROGEAR-2046 Update mobile services dashboard for mobile app metrics

### DIFF
--- a/roles/provision-metrics-apb/files/mobile-services-dashboard.json
+++ b/roles/provision-metrics-apb/files/mobile-services-dashboard.json
@@ -752,13 +752,767 @@
       ],
       "title": "Sync",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Mobile app metrics",
+      "type": "row"
+    },
+    {
+      "content": "# Mobile App Metrics\n\nMobile App Metrics service provides analytics about the mobile apps installed on user devices.\n\nFind out more at [project website](https://github.com/aerogear/aerogear-metrics-api/).",
+      "gridPos": {
+        "h": 4,
+        "w": 13,
+        "x": 0,
+        "y": 25
+      },
+      "id": 27,
+      "links": [],
+      "mode": "markdown",
+      "title": "",
+      "transparent": false,
+      "type": "text"
+    },
+    {
+      "folderId": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 13,
+        "y": 25
+      },
+      "headings": false,
+      "id": 31,
+      "limit": 10,
+      "links": [],
+      "query": "",
+      "recent": false,
+      "search": true,
+      "starred": false,
+      "tags": [
+        "mobile-app-metrics"
+      ],
+      "title": "Detail dashboards",
+      "type": "dashlist"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Postgres",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 29
+      },
+      "id": 43,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "count",
+      "targets": [
+        {
+          "alias": "",
+          "expr": "",
+          "format": "table",
+          "hide": false,
+          "intervalFactor": 1,
+          "rawSql": "SELECT\n  count(distinct latestEntryInTimeRange.clientId)\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time)\n          group by clientId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange;",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "# of unique clients",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Postgres",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 8,
+        "y": 29
+      },
+      "id": 42,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "count",
+      "targets": [
+        {
+          "alias": "",
+          "expr": "",
+          "format": "table",
+          "intervalFactor": 1,
+          "rawSql": "SELECT count(*)\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time);",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "# of app launches",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Postgres",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 15,
+        "y": 29
+      },
+      "id": 41,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "count",
+      "targets": [
+        {
+          "alias": "",
+          "expr": "",
+          "format": "table",
+          "intervalFactor": 1,
+          "rawSql": "SELECT\n  count(distinct data->'app'->>'id')\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time) and data->'app' ? 'id';",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "# of apps",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Postgres",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 11,
+        "x": 0,
+        "y": 33
+      },
+      "id": 36,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "expr": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>id)::text as metric\nFROM (select entry.clientId, entry.event_time, entry.data from mobileAppMetrics entry inner join (select clientId, max(event_time) as latestEntryTime from mobileAppMetrics where $__timeFilter(event_time) group by clientId) latestEntry on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime) latestEntryInTimeRange\n  GROUP by latestEntryInTimeRange.data->'app'->>id\n  ORDER by latestEntryInTimeRange.data->'app'->>id;",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "rawSql": "SELECT\n  $__timeGroup(event_time,$resolutionInterval),\n  count(*),\n  (data->'app'->>'id')::text as metric\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time) and data->'app' ? 'id'\n  GROUP by data->'app'->>'id', time\n  ORDER by data->'app'->>'id';",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "# of launches per app",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Postgres",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 11,
+        "x": 11,
+        "y": 33
+      },
+      "id": 33,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": false,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "alias": "",
+          "expr": "",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "rawSql": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>'id')::text as metric\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, data->'app'->>'id' as appId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time) and data->'app' ? 'id' \n          group by clientId, appId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.data->'app'->>'id' = latestEntry.appId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange\n  where latestEntryInTimeRange.data->'app' ? 'id'\n  GROUP by latestEntryInTimeRange.data->'app'->>'id'\n  ORDER by latestEntryInTimeRange.data->'app'->>'id';",
+          "refId": "A"
+        }
+      ],
+      "title": "# of unique clients per app",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Postgres",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 11,
+        "x": 0,
+        "y": 42
+      },
+      "id": 29,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "expr": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>id)::text as metric\nFROM (select entry.clientId, entry.event_time, entry.data from mobileAppMetrics entry inner join (select clientId, max(event_time) as latestEntryTime from mobileAppMetrics where $__timeFilter(event_time) group by clientId) latestEntry on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime) latestEntryInTimeRange\n  GROUP by latestEntryInTimeRange.data->'app'->>id\n  ORDER by latestEntryInTimeRange.data->'app'->>id;",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "rawSql": "SELECT\n  $__timeGroup(event_time,$resolutionInterval),\n  count(*),\n  (data->'device'->>'platform')::text as metric\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time) and data->'device' ? 'platform'\n  GROUP by data->'device'->>'platform', time\n  ORDER by data->'device'->>'platform';",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "# of launches per platform",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Postgres",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 11,
+        "x": 11,
+        "y": 42
+      },
+      "id": 37,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": false,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "alias": "",
+          "expr": "",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "rawSql": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'device'->>'platform')::text as metric\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time) \n          group by clientId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange\n  where latestEntryInTimeRange.data->'device' ? 'platform'\n  GROUP by latestEntryInTimeRange.data->'device'->>'platform'\n  ORDER by latestEntryInTimeRange.data->'device'->>'platform';",
+          "refId": "A"
+        }
+      ],
+      "title": "# of unique clients per platform",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Postgres",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 11,
+        "x": 0,
+        "y": 51
+      },
+      "id": 38,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "expr": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>id)::text as metric\nFROM (select entry.clientId, entry.event_time, entry.data from mobileAppMetrics entry inner join (select clientId, max(event_time) as latestEntryTime from mobileAppMetrics where $__timeFilter(event_time) group by clientId) latestEntry on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime) latestEntryInTimeRange\n  GROUP by latestEntryInTimeRange.data->'app'->>id\n  ORDER by latestEntryInTimeRange.data->'app'->>id;",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "rawSql": "SELECT\n  $__timeGroup(event_time,$resolutionInterval),\n  count(*),\n  (data->'app'->>'sdkVersion')::text as metric\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time) and data->'app' ? 'sdkVersion'\n  GROUP by data->'app'->>'sdkVersion', time\n  ORDER by data->'app'->>'sdkVersion';",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "# of launches per sdk version",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Postgres",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 11,
+        "x": 11,
+        "y": 51
+      },
+      "id": 39,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": false,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "alias": "",
+          "expr": "",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "rawSql": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>'sdkVersion')::text as metric\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time) \n          group by clientId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange\n  where latestEntryInTimeRange.data->'app' ? 'sdkVersion'\n  GROUP by latestEntryInTimeRange.data->'app'->>'sdkVersion'\n  ORDER by latestEntryInTimeRange.data->'app'->>'sdkVersion';",
+          "refId": "A"
+        }
+      ],
+      "title": "# of unique clients per sdk version",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
     }
   ],
+  "refresh": false,
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "mobile-services"
+  ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "auto",
+          "value": "$__auto_interval_resolutionInterval"
+        },
+        "hide": 0,
+        "label": "Resolution",
+        "name": "resolutionInterval",
+        "options": [
+          {
+            "selected": true,
+            "text": "auto",
+            "value": "$__auto_interval_resolutionInterval"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "type": "interval"
+      }
+    ]
   },
   "time": {
     "from": "now/d",

--- a/roles/provision-metrics-apb/files/mobile-services-dashboard.json
+++ b/roles/provision-metrics-apb/files/mobile-services-dashboard.json
@@ -759,7 +759,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 2
       },
       "id": 20,
       "panels": [],
@@ -772,7 +772,7 @@
         "h": 4,
         "w": 13,
         "x": 0,
-        "y": 25
+        "y": 3
       },
       "id": 27,
       "links": [],
@@ -780,28 +780,6 @@
       "title": "",
       "transparent": false,
       "type": "text"
-    },
-    {
-      "folderId": 0,
-      "gridPos": {
-        "h": 4,
-        "w": 9,
-        "x": 13,
-        "y": 25
-      },
-      "headings": false,
-      "id": 31,
-      "limit": 10,
-      "links": [],
-      "query": "",
-      "recent": false,
-      "search": true,
-      "starred": false,
-      "tags": [
-        "mobile-app-metrics"
-      ],
-      "title": "Detail dashboards",
-      "type": "dashlist"
     },
     {
       "cacheTimeout": null,
@@ -823,9 +801,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 0,
-        "y": 29
+        "w": 3,
+        "x": 13,
+        "y": 3
       },
       "id": 43,
       "interval": null,
@@ -906,9 +884,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 7,
-        "x": 8,
-        "y": 29
+        "w": 3,
+        "x": 16,
+        "y": 3
       },
       "id": 42,
       "interval": null,
@@ -988,9 +966,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 7,
-        "x": 15,
-        "y": 29
+        "w": 3,
+        "x": 19,
+        "y": 3
       },
       "id": 41,
       "interval": null,
@@ -1061,7 +1039,7 @@
         "h": 9,
         "w": 11,
         "x": 0,
-        "y": 33
+        "y": 7
       },
       "id": 36,
       "legend": {
@@ -1146,7 +1124,7 @@
         "h": 9,
         "w": 11,
         "x": 11,
-        "y": 33
+        "y": 7
       },
       "id": 33,
       "interval": null,
@@ -1188,7 +1166,7 @@
         "h": 9,
         "w": 11,
         "x": 0,
-        "y": 42
+        "y": 16
       },
       "id": 29,
       "legend": {
@@ -1273,7 +1251,7 @@
         "h": 9,
         "w": 11,
         "x": 11,
-        "y": 42
+        "y": 16
       },
       "id": 37,
       "interval": null,
@@ -1315,7 +1293,7 @@
         "h": 9,
         "w": 11,
         "x": 0,
-        "y": 51
+        "y": 25
       },
       "id": 38,
       "legend": {
@@ -1400,7 +1378,7 @@
         "h": 9,
         "w": 11,
         "x": 11,
-        "y": 51
+        "y": 25
       },
       "id": 39,
       "interval": null,

--- a/roles/provision-metrics-apb/files/mobile-services-dashboard.json
+++ b/roles/provision-metrics-apb/files/mobile-services-dashboard.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "links": [],
@@ -762,652 +762,407 @@
         "y": 2
       },
       "id": 20,
-      "panels": [],
+      "panels": [
+        {
+          "content": "# Mobile App Metrics\n\nMobile App Metrics service provides analytics about the mobile apps installed on user devices.\n\nFind out more at [project website](https://github.com/aerogear/aerogear-metrics-api/).",
+          "gridPos": {
+            "h": 4,
+            "w": 13,
+            "x": 0,
+            "y": 3
+          },
+          "id": 27,
+          "links": [],
+          "mode": "markdown",
+          "title": "",
+          "transparent": false,
+          "type": "text"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "Postgres",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 13,
+            "y": 3
+          },
+          "id": 43,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "count",
+          "targets": [
+            {
+              "alias": "",
+              "expr": "",
+              "format": "table",
+              "hide": false,
+              "intervalFactor": 1,
+              "rawSql": "SELECT\n  count(distinct latestEntryInTimeRange.clientId)\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time)\n          group by clientId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange;",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "Unique clients",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "Postgres",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 16,
+            "y": 3
+          },
+          "id": 42,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "count",
+          "targets": [
+            {
+              "alias": "",
+              "expr": "",
+              "format": "table",
+              "intervalFactor": 1,
+              "rawSql": "SELECT count(*)\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time);",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "App launches",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "Postgres",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 19,
+            "y": 3
+          },
+          "id": 41,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "count",
+          "targets": [
+            {
+              "alias": "",
+              "expr": "",
+              "format": "table",
+              "intervalFactor": 1,
+              "rawSql": "SELECT\n  count(distinct data->'app'->>'appId')\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time) and data->'app' ? 'appId';",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "",
+          "title": "Apps",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "aliasColors": {},
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": 0
+          },
+          "datasource": "Postgres",
+          "fontSize": "80%",
+          "format": "short",
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 7
+          },
+          "id": 33,
+          "interval": null,
+          "legend": {
+            "show": true,
+            "sort": "current",
+            "sortDesc": false,
+            "values": true
+          },
+          "legendType": "Under graph",
+          "links": [],
+          "maxDataPoints": 3,
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "strokeWidth": 1,
+          "targets": [
+            {
+              "alias": "",
+              "expr": "",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "rawSql": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>'appId')::text as metric\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, data->'app'->>'appId' as appId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time) and data->'app' ? 'appId' \n          group by clientId, appId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.data->'app'->>'appId' = latestEntry.appId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange\n  where latestEntryInTimeRange.data->'app' ? 'appId'\n  GROUP by latestEntryInTimeRange.data->'app'->>'appId'\n  ORDER by latestEntryInTimeRange.data->'app'->>'appId';",
+              "refId": "A"
+            }
+          ],
+          "title": "Unique clients per app",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": 0
+          },
+          "datasource": "Postgres",
+          "fontSize": "80%",
+          "format": "short",
+          "gridPos": {
+            "h": 9,
+            "w": 7,
+            "x": 8,
+            "y": 7
+          },
+          "id": 37,
+          "interval": null,
+          "legend": {
+            "show": true,
+            "sort": "current",
+            "sortDesc": false,
+            "values": true
+          },
+          "legendType": "Under graph",
+          "links": [],
+          "maxDataPoints": 3,
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "strokeWidth": 1,
+          "targets": [
+            {
+              "alias": "",
+              "expr": "",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "rawSql": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'device'->>'platform')::text as metric\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time) \n          group by clientId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange\n  where latestEntryInTimeRange.data->'device' ? 'platform'\n  GROUP by latestEntryInTimeRange.data->'device'->>'platform'\n  ORDER by latestEntryInTimeRange.data->'device'->>'platform';",
+              "refId": "A"
+            }
+          ],
+          "title": "Unique clients per platform",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": 0
+          },
+          "datasource": "Postgres",
+          "fontSize": "80%",
+          "format": "short",
+          "gridPos": {
+            "h": 9,
+            "w": 7,
+            "x": 15,
+            "y": 7
+          },
+          "id": 39,
+          "interval": null,
+          "legend": {
+            "show": true,
+            "sort": "current",
+            "sortDesc": false,
+            "values": true
+          },
+          "legendType": "Under graph",
+          "links": [],
+          "maxDataPoints": 3,
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "strokeWidth": 1,
+          "targets": [
+            {
+              "alias": "",
+              "expr": "",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "rawSql": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>'sdkVersion')::text as metric\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time) \n          group by clientId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange\n  where latestEntryInTimeRange.data->'app' ? 'sdkVersion'\n  GROUP by latestEntryInTimeRange.data->'app'->>'sdkVersion'\n  ORDER by latestEntryInTimeRange.data->'app'->>'sdkVersion';",
+              "refId": "A"
+            }
+          ],
+          "title": "Unique clients per sdk version",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        }
+      ],
       "title": "Mobile app metrics",
       "type": "row"
-    },
-    {
-      "content": "# Mobile App Metrics\n\nMobile App Metrics service provides analytics about the mobile apps installed on user devices.\n\nFind out more at [project website](https://github.com/aerogear/aerogear-metrics-api/).",
-      "gridPos": {
-        "h": 4,
-        "w": 13,
-        "x": 0,
-        "y": 3
-      },
-      "id": 27,
-      "links": [],
-      "mode": "markdown",
-      "title": "",
-      "transparent": false,
-      "type": "text"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "Postgres",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 13,
-        "y": 3
-      },
-      "id": 43,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "count",
-      "targets": [
-        {
-          "alias": "",
-          "expr": "",
-          "format": "table",
-          "hide": false,
-          "intervalFactor": 1,
-          "rawSql": "SELECT\n  count(distinct latestEntryInTimeRange.clientId)\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time)\n          group by clientId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange;",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "# of unique clients",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "Postgres",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 16,
-        "y": 3
-      },
-      "id": 42,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "count",
-      "targets": [
-        {
-          "alias": "",
-          "expr": "",
-          "format": "table",
-          "intervalFactor": 1,
-          "rawSql": "SELECT count(*)\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time);",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "# of app launches",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "Postgres",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 19,
-        "y": 3
-      },
-      "id": 41,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "count",
-      "targets": [
-        {
-          "alias": "",
-          "expr": "",
-          "format": "table",
-          "intervalFactor": 1,
-          "rawSql": "SELECT\n  count(distinct data->'app'->>'id')\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time) and data->'app' ? 'id';",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "# of apps",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "avg"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Postgres",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 11,
-        "x": 0,
-        "y": 7
-      },
-      "id": 36,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "",
-          "expr": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>id)::text as metric\nFROM (select entry.clientId, entry.event_time, entry.data from mobileAppMetrics entry inner join (select clientId, max(event_time) as latestEntryTime from mobileAppMetrics where $__timeFilter(event_time) group by clientId) latestEntry on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime) latestEntryInTimeRange\n  GROUP by latestEntryInTimeRange.data->'app'->>id\n  ORDER by latestEntryInTimeRange.data->'app'->>id;",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "rawSql": "SELECT\n  $__timeGroup(event_time,$resolutionInterval),\n  count(*),\n  (data->'app'->>'id')::text as metric\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time) and data->'app' ? 'id'\n  GROUP by data->'app'->>'id', time\n  ORDER by data->'app'->>'id';",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "# of launches per app",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "cacheTimeout": null,
-      "combine": {
-        "label": "Others",
-        "threshold": 0
-      },
-      "datasource": "Postgres",
-      "fontSize": "80%",
-      "format": "short",
-      "gridPos": {
-        "h": 9,
-        "w": 11,
-        "x": 11,
-        "y": 7
-      },
-      "id": 33,
-      "interval": null,
-      "legend": {
-        "show": true,
-        "sort": "current",
-        "sortDesc": false,
-        "values": true
-      },
-      "legendType": "Under graph",
-      "links": [],
-      "maxDataPoints": 3,
-      "nullPointMode": "connected",
-      "pieType": "pie",
-      "strokeWidth": 1,
-      "targets": [
-        {
-          "alias": "",
-          "expr": "",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "rawSql": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>'id')::text as metric\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, data->'app'->>'id' as appId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time) and data->'app' ? 'id' \n          group by clientId, appId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.data->'app'->>'id' = latestEntry.appId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange\n  where latestEntryInTimeRange.data->'app' ? 'id'\n  GROUP by latestEntryInTimeRange.data->'app'->>'id'\n  ORDER by latestEntryInTimeRange.data->'app'->>'id';",
-          "refId": "A"
-        }
-      ],
-      "title": "# of unique clients per app",
-      "type": "grafana-piechart-panel",
-      "valueName": "current"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Postgres",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 11,
-        "x": 0,
-        "y": 16
-      },
-      "id": 29,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "",
-          "expr": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>id)::text as metric\nFROM (select entry.clientId, entry.event_time, entry.data from mobileAppMetrics entry inner join (select clientId, max(event_time) as latestEntryTime from mobileAppMetrics where $__timeFilter(event_time) group by clientId) latestEntry on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime) latestEntryInTimeRange\n  GROUP by latestEntryInTimeRange.data->'app'->>id\n  ORDER by latestEntryInTimeRange.data->'app'->>id;",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "rawSql": "SELECT\n  $__timeGroup(event_time,$resolutionInterval),\n  count(*),\n  (data->'device'->>'platform')::text as metric\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time) and data->'device' ? 'platform'\n  GROUP by data->'device'->>'platform', time\n  ORDER by data->'device'->>'platform';",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "# of launches per platform",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "cacheTimeout": null,
-      "combine": {
-        "label": "Others",
-        "threshold": 0
-      },
-      "datasource": "Postgres",
-      "fontSize": "80%",
-      "format": "short",
-      "gridPos": {
-        "h": 9,
-        "w": 11,
-        "x": 11,
-        "y": 16
-      },
-      "id": 37,
-      "interval": null,
-      "legend": {
-        "show": true,
-        "sort": "current",
-        "sortDesc": false,
-        "values": true
-      },
-      "legendType": "Under graph",
-      "links": [],
-      "maxDataPoints": 3,
-      "nullPointMode": "connected",
-      "pieType": "pie",
-      "strokeWidth": 1,
-      "targets": [
-        {
-          "alias": "",
-          "expr": "",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "rawSql": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'device'->>'platform')::text as metric\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time) \n          group by clientId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange\n  where latestEntryInTimeRange.data->'device' ? 'platform'\n  GROUP by latestEntryInTimeRange.data->'device'->>'platform'\n  ORDER by latestEntryInTimeRange.data->'device'->>'platform';",
-          "refId": "A"
-        }
-      ],
-      "title": "# of unique clients per platform",
-      "type": "grafana-piechart-panel",
-      "valueName": "current"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Postgres",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 11,
-        "x": 0,
-        "y": 25
-      },
-      "id": 38,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "alias": "",
-          "expr": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>id)::text as metric\nFROM (select entry.clientId, entry.event_time, entry.data from mobileAppMetrics entry inner join (select clientId, max(event_time) as latestEntryTime from mobileAppMetrics where $__timeFilter(event_time) group by clientId) latestEntry on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime) latestEntryInTimeRange\n  GROUP by latestEntryInTimeRange.data->'app'->>id\n  ORDER by latestEntryInTimeRange.data->'app'->>id;",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "rawSql": "SELECT\n  $__timeGroup(event_time,$resolutionInterval),\n  count(*),\n  (data->'app'->>'sdkVersion')::text as metric\nFROM mobileAppMetrics\n  WHERE $__timeFilter(event_time) and data->'app' ? 'sdkVersion'\n  GROUP by data->'app'->>'sdkVersion', time\n  ORDER by data->'app'->>'sdkVersion';",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "# of launches per sdk version",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "cacheTimeout": null,
-      "combine": {
-        "label": "Others",
-        "threshold": 0
-      },
-      "datasource": "Postgres",
-      "fontSize": "80%",
-      "format": "short",
-      "gridPos": {
-        "h": 9,
-        "w": 11,
-        "x": 11,
-        "y": 25
-      },
-      "id": 39,
-      "interval": null,
-      "legend": {
-        "show": true,
-        "sort": "current",
-        "sortDesc": false,
-        "values": true
-      },
-      "legendType": "Under graph",
-      "links": [],
-      "maxDataPoints": 3,
-      "nullPointMode": "connected",
-      "pieType": "pie",
-      "strokeWidth": 1,
-      "targets": [
-        {
-          "alias": "",
-          "expr": "",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "rawSql": "SELECT\n  now() as time,\n  count(latestEntryInTimeRange.clientId),\n  (latestEntryInTimeRange.data->'app'->>'sdkVersion')::text as metric\nFROM\n    (select entry.clientId, entry.event_time, entry.data \n      from mobileAppMetrics entry \n      inner join \n        (select clientId, max(event_time) as latestEntryTime \n          from mobileAppMetrics \n          where $__timeFilter(event_time) \n          group by clientId\n        ) \n        latestEntry \n        on entry.clientId = latestEntry.clientId and entry.event_time = latestEntryTime\n      ) latestEntryInTimeRange\n  where latestEntryInTimeRange.data->'app' ? 'sdkVersion'\n  GROUP by latestEntryInTimeRange.data->'app'->>'sdkVersion'\n  ORDER by latestEntryInTimeRange.data->'app'->>'sdkVersion';",
-          "refId": "A"
-        }
-      ],
-      "title": "# of unique clients per sdk version",
-      "type": "grafana-piechart-panel",
-      "valueName": "current"
     }
   ],
   "refresh": false,


### PR DESCRIPTION
Update mobile services dashboard for mobile app metrics.

Screenshot:
![screenshot from 2018-03-02 17-31-12](https://user-images.githubusercontent.com/376732/36903714-90b5af22-1e3f-11e8-81fc-409c409436f5.png)


Notes:
* Because of https://issues.jboss.org/browse/AEROGEAR-2199, no "Version" and "Provisioned" boxes unlike Keycloak and Sync rows.
* No links to detail dashboards. Detail dashboards: graphs that filter data based on app id, platform etc. similar to <https://snapshot.raintank.io/dashboard/snapshot/onsMFzn5t2uAZBB7NhGJAAVYFaeA9Jxq?orgId=2> but with more filters.

Data in the screenshot is generated using https://github.com/aliok/aerogear-mobile-metrics-api-data-generator



