### PR TITLE
group pods under aerogear-metrics application

### DIFF
--- a/roles/provision-metrics-apb/tasks/provision-app-metrics.yml
+++ b/roles/provision-metrics-apb/tasks/provision-app-metrics.yml
@@ -3,8 +3,8 @@
     name: "{{ postgres_claim_name}}"
     namespace: "{{ namespace }}"
     labels:
-      app: aerogear-app-metrics
-      service: aerogear-app-metrics
+      app: aerogear-metrics
+      service: postgres
     access_modes:
       - ReadWriteMany
     resources_requests:
@@ -16,15 +16,15 @@
     name: postgres
     namespace: '{{ namespace }}'
     labels:
-      app: postgres
-      service: aerogear-app-metrics
+      app: aerogear-metrics
+      service: postgres
     replicas: 1
     selector:
-      app: postgres
-      service: aerogear-app-metrics
+      app: aerogear-metrics
+      service: postgres
     spec_template_metadata_labels:
-      app: postgres
-      service: aerogear-app-metrics
+      app: aerogear-metrics
+      service: postgres
     containers:
     - name: postgresql
       image: "{{ postgres_image }}:{{ postgres_version }}"
@@ -51,11 +51,11 @@
     name: postgres-internal
     namespace: '{{ namespace }}'
     labels:
-      app: postgres
-      service: aerogear-app-metrics
+      app: aerogear-metrics
+      service: postgres
     selector:
-      app: postgres
-      service: aerogear-app-metrics
+      app: aerogear-metrics
+      service: postgres
     ports:
       - name: postgres
         port: "{{ postgres_port }}"
@@ -66,14 +66,14 @@
     name: aerogear-app-metrics
     namespace: '{{ namespace }}'
     labels:
-      app: aerogear-app-metrics
+      app: aerogear-metrics
       service: aerogear-app-metrics
     replicas: 1
     selector:
-      app: aerogear-app-metrics
+      app: aerogear-metrics
       service: aerogear-app-metrics
     spec_template_metadata_labels:
-      app: aerogear-app-metrics
+      app: aerogear-metrics
       service: aerogear-app-metrics
     containers:
     - name: aerogear-app-metrics
@@ -100,10 +100,10 @@
     name: aerogear-app-metrics
     namespace: '{{ namespace }}'
     labels:
-      app: aerogear-app-metrics
+      app: aerogear-metrics
       service: aerogear-app-metrics
     selector:
-      app: aerogear-app-metrics
+      app: aerogear-metrics
       service: aerogear-app-metrics
     ports:
       - name: web
@@ -115,12 +115,12 @@
     name: aerogear-app-metrics
     namespace: '{{ namespace }}'
     labels:
-      app: aerogear-app-metrics
+      app: aerogear-metrics
       service: aerogear-app-metrics
     to_name: aerogear-app-metrics
     spec_port_target_port: web
   register: app_metrics_route
-
+  
     
 # Check the containers in the aerogear-app-metrics pod and make sure they are all ready
 - name: "Wait for all aerogear-app-metrics containers to become ready"

--- a/roles/provision-metrics-apb/tasks/provision-grafana.yml
+++ b/roles/provision-metrics-apb/tasks/provision-grafana.yml
@@ -30,8 +30,8 @@
     name: '{{ grafana_claim_name }}'
     namespace: "{{ namespace }}"
     labels:
-      app: grafana
-      service: prometheus
+      app: aerogear-metrics
+      service: grafana
     access_modes:
       - ReadWriteMany
     resources_requests:
@@ -43,15 +43,15 @@
     name: grafana
     namespace: '{{ namespace }}'
     labels:
-      app: grafana
-      service: prometheus
+      app: aerogear-metrics
+      service: grafana
     replicas: 1
     selector:
-      app: grafana
-      service: prometheus
+      app: aerogear-metrics
+      service: grafana
     spec_template_metadata_labels:
-      app: grafana
-      service: prometheus
+      app: aerogear-metrics
+      service: grafana
     spec_template_spec_service_account_name: '{{ proxy_serviceaccount_name }}'
     containers:
     - name: grafana-oauth-proxy
@@ -115,11 +115,11 @@
     name: '{{ grafana_service_name }}'
     namespace: '{{ namespace }}'
     labels:
-      app: grafana
-      service: prometheus
+      app: aerogear-metrics
+      service: grafana
     selector:
-      app: grafana
-      service: prometheus
+      app: aerogear-metrics
+      service: grafana
     ports:
       - name: web
         port: 443
@@ -130,11 +130,11 @@
     name: '{{ grafana_internal_service_name }}'
     namespace: '{{ namespace }}'
     labels:
-      app: grafana
-      service: prometheus
+      app: aerogear-metrics
+      service: grafana
     selector:
-      app: grafana
-      service: prometheus
+      app: aerogear-metrics
+      service: grafana
     ports:
       - name: web
         port: 80
@@ -145,8 +145,8 @@
     name: '{{ grafana_route_name }}'
     namespace: '{{ namespace }}'
     labels:
-      app: grafana
-      service: prometheus
+      app: aerogear-metrics
+      service: grafana
     to_name: grafana
     spec_port_target_port: web
     spec_tls_termination: edge

--- a/roles/provision-metrics-apb/tasks/provision-prometheus.yml
+++ b/roles/provision-metrics-apb/tasks/provision-prometheus.yml
@@ -11,7 +11,7 @@
     name: '{{ prometheus_claim_name }}'
     namespace: "{{ namespace }}"
     labels:
-      app: prometheus
+      app: aerogear-metrics
       service: prometheus
     access_modes:
       - ReadWriteOnce
@@ -24,14 +24,14 @@
     name: prometheus
     namespace: '{{ namespace }}'
     labels:
-      app: prometheus
+      app: aerogear-metrics
       service: prometheus
     replicas: 1
     selector:
-      app: prometheus
+      app: aerogear-metrics
       service: prometheus
     spec_template_metadata_labels:
-      app: prometheus
+      app: aerogear-metrics
       service: prometheus
     spec_template_spec_service_account_name: '{{ proxy_serviceaccount_name }}'
     containers:
@@ -75,10 +75,10 @@
     name: '{{ prometheus_service_name }}'
     namespace: '{{ namespace }}'
     labels:
-      app: prometheus
+      app: aerogear-metrics
       service: prometheus
     selector:
-      app: prometheus
+      app: aerogear-metrics
       service: prometheus
     ports:
       - name: web
@@ -90,10 +90,10 @@
     name: '{{ prometheus_internal_service_name }}'
     namespace: '{{ namespace }}'
     labels:
-      app: prometheus
+      app: aerogear-metrics
       service: prometheus
     selector:
-      app: prometheus
+      app: aerogear-metrics
       service: prometheus
     ports:
       - name: web
@@ -105,7 +105,7 @@
     name: '{{ prometheus_route_name }}'
     namespace: '{{ namespace }}'
     labels:
-      app: prometheus
+      app: aerogear-metrics
       service: prometheus
     to_name: prometheus
     spec_port_target_port: web


### PR DESCRIPTION
This PR groups all the metrics pods under the application label aerogear-metrics.

Related issue: https://github.com/aerogearcatalog/metrics-apb/issues/30