### PR TITLE
integrate metrics service with mobile cli

### DIFF
--- a/roles/deprovision-metrics-apb/tasks/main.yml
+++ b/roles/deprovision-metrics-apb/tasks/main.yml
@@ -40,6 +40,11 @@
     namespace: '{{ namespace }}'
     state: absent
 
+- k8s_v1_config_map:
+    name: metrics
+    namespace: '{{ namespace }}'
+    state: absent
+
 - k8s_v1_service_account:
     name: '{{ proxy_serviceaccount_name }}'
     namespace: '{{ namespace }}'

--- a/roles/provision-metrics-apb/tasks/provision-app-metrics.yml
+++ b/roles/provision-metrics-apb/tasks/provision-app-metrics.yml
@@ -110,7 +110,7 @@
         port: 443
         target_port: '{{ api_server_port }}'
 
-- name: Create api server route
+- name: Create api server https route
   openshift_v1_route:
     name: aerogear-app-metrics
     namespace: '{{ namespace }}'
@@ -119,9 +119,22 @@
       service: aerogear-app-metrics
     to_name: aerogear-app-metrics
     spec_port_target_port: web
+    tls_termination: edge
+    tls_insecure_edge_termination_policy: Redirect
   register: app_metrics_route
 
-    
+# Create the configmap used for the client config
+- name: Create metrics configmap template
+  template:
+    src: configmap.yml.j2
+    dest: /tmp/configmap.yaml
+
+- name: Create metrics public client config map
+  shell: oc create -f /tmp/configmap.yaml -n {{ namespace }}
+
+- name: delete configmap template file
+  file: path=/tmp/configmap.yaml state=absent
+
 # Check the containers in the aerogear-app-metrics pod and make sure they are all ready
 - name: "Wait for all aerogear-app-metrics containers to become ready"
   shell: oc get pods --namespace={{ namespace }} --selector="deploymentconfig=aerogear-app-metrics" -o jsonpath='{.items[*].status.containerStatuses[?(@.ready==true)].ready}'| wc -w
@@ -140,7 +153,8 @@
 
 - name: Wait for app-metrics health endpoint to report healthy
   uri:
-    url: http://{{ app_metrics_route.route.spec.host }}/healthz
+    url: https://{{ app_metrics_route.route.spec.host }}/healthz
+    validate_certs: no
     status_code: 200
   register: app_metrics_health
   until: app_metrics_health.status == 200

--- a/roles/provision-metrics-apb/templates/configmap.yml.j2
+++ b/roles/provision-metrics-apb/templates/configmap.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics
+  namespace: {{ namespace }}
+  labels:
+    mobile: enabled
+    serviceName: metrics
+data:
+  id: metrics
+  type: metrics
+  name: metrics
+  uri: https://{{ app_metrics_route.route.spec.host }}/metrics

--- a/roles/test-deprovision-apb/tasks/main.yml
+++ b/roles/test-deprovision-apb/tasks/main.yml
@@ -66,6 +66,7 @@
     - '{{ grafana_datasources_configmap_name }}'
     - '{{ grafana_dashboards_configmap_name }}'
     - '{{ prometheus_configmap_name }}'
+    - metrics
 
 - name: Check that all persistent volume claims have been removed
   shell: oc get pvc --namespace={{ namespace }} {{ item }} 2>&1


### PR DESCRIPTION
This PR adds the config map to the metrics apb that is required to get the client config via the mobile-cli. It also changes the URL of the app metrics service to https and adds some additional tests.

To verify:

1. Deploy the APB
2. Provision a Client App to the same namespace, e.g. https://github.com/aerogearcatalog/android-app-apb
3. Retrieve the configuration via `mobile get clientconfig <app name> --namespace=<project> -o json`. Ths config should contain a section for metrics. The only config value is the URL.