### PR TITLE
Pass config variables correctly

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -1,6 +1,6 @@
 version: 1.0
 name: metrics-apb
-description: Installs a metrics service based on Prometheus and Grafana
+description: UPDATE Installs a metrics service based on Prometheus and Grafana
 bindable: False
 async: optional
 tags:
@@ -33,13 +33,13 @@ plans:
         type: number
         title: Postgres Storage Size (Gb)
       - name: POSTGRES_USER
-        description: Username that will be used to connect to postgres
+        description: Username that will be used to connect to postgres ('user' will be used if blank)
         default: user
         type: string
         required: False
         title: Postgres User
       - name: POSTGRES_PASSWORD
-        description: Password to connect to Postgres ( generated if blank )
+        description: Password to connect to Postgres (generated if blank)
         type: string
         required: False
         title: Postgres Password

--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -20,8 +20,8 @@ api_server_port: 3000
 postgres_image: "registry.access.redhat.com/rhscl/postgresql-96-rhel7"
 postgres_version: "latest"
 postgres_port: 5432
-postgres_user: "{{ lookup('env','POSTGRES_USER') | default('user', true) }}"
-postgres_password: "{{ lookup('password', '/tmp/pass chars=ascii_letters,digits') }}"
+postgres_user: "{{ POSTGRES_USER | default('user', true) }}"
+postgres_password: "{{ POSTGRES_PASSWORD | default(lookup('password', '/tmp/pass chars=ascii_letters,digits'), true) }}"
 postgres_database: "aerogear_mobile_metrics"
 
 # OAuth Proxy values


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-2351

### Verification
1. Clone this branch, build & push this APB
2. Provision **without** specifying `Postgres User` & `Postgres Password`
* provisioning pod should finish without error
3. Provision **with** specifying `Postgres User` & `Postgres Password`
* after it's provisioned, check aerogear-app-metrics & postgres-metrics DC environment variables - it should contain your values in `POSTGRESQL_USER` & `POSTGRESQL_PASSWORD` variables