### PR TITLE
fix: use aerogear/grafana docker image

### DIFF
--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -5,7 +5,7 @@ prometheus_port: 9090
 prometheus_proxy_port: 4180
 
 # Grafana values
-grafana_image: "docker.io/aerogearcatalog/grafana"
+grafana_image: "docker.io/aerogear/grafana"
 grafana_version: "latest"
 grafana_port: 3000
 grafana_proxy_port: 4181


### PR DESCRIPTION
It never made sense to have this image in the aerogearcatalog Dockerhub org. However, we didn't have permissions at the time.

Now that I have access, I've pushed it to the right org.