### PR TITLE
🐛 AEROGEAR-3134 Use DISTINCT when aggregating unique clients for security check metrics

### DIFF
--- a/roles/provision-metrics-apb/files/mobile-services-dashboard.json
+++ b/roles/provision-metrics-apb/files/mobile-services-dashboard.json
@@ -1481,7 +1481,7 @@
               "expr": "",
               "format": "table",
               "intervalFactor": 1,
-              "rawSql": "SELECT count(clientId)\nFROM mobileAppMetrics\nWHERE $__timeFilter(event_time)\n  AND event_type='security'\n  AND data ? 'security';",
+              "rawSql": "SELECT count(DISTINCT clientId)\nFROM mobileAppMetrics\nWHERE $__timeFilter(event_time)\n  AND event_type='security'\n  AND data ? 'security';",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-3134

This change is for clientId count on the 'Mobile security metrics' panel on the 'Mobile Services' dashboard.

The client count on the main 'Mobile security metrics' dashboard is already using 'count(DISTINCT clientId)'.