### PR TITLE
Configure Prometheus to auto discover pods as scraping targets

### DIFF
--- a/roles/provision-metrics-apb/templates/prometheus-config-map.yml.j2
+++ b/roles/provision-metrics-apb/templates/prometheus-config-map.yml.j2
@@ -77,3 +77,38 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_service_annotation_org_aerogear_metrics_plain_endpoint]
         regex: (.+)
         target_label: __metrics_path__
+
+  # auto discovery for pods as scrape targets
+  # set org.aerogear.metrics/plain_endpoint: /metrics as an annotation on the pod to make it targeted by Prometheus
+  # see https://github.com/prometheus/prometheus/blob/03a9e7f72e072c6d29f422425d8acd91a957836b/documentation/examples/prometheus-kubernetes.yml#L246
+  # unlike services, no SSL support for pods
+  - job_name: mcp-plain-pods
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - {{ namespace }}
+      relabel_configs:
+      - action: keep
+        regex: \/.*
+        source_labels:
+          - __meta_kubernetes_pod_annotation_org_aerogear_metrics_plain_endpoint
+      - source_labels:
+          - __address__
+        target_label: __param_target
+      - source_labels:
+          - __param_target
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels:
+          - __meta_kubernetes_namespace
+        target_label: kubernetes_namespace
+      - source_labels:
+          - __meta_kubernetes_pod_name
+        action: replace
+        target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_annotation_org_aerogear_metrics_plain_endpoint]
+        regex: (.+)
+        target_label: __metrics_path__

--- a/roles/provision-metrics-apb/templates/prometheus-config-map.yml.j2
+++ b/roles/provision-metrics-apb/templates/prometheus-config-map.yml.j2
@@ -83,13 +83,13 @@ scrape_configs:
   # see https://github.com/prometheus/prometheus/blob/03a9e7f72e072c6d29f422425d8acd91a957836b/documentation/examples/prometheus-kubernetes.yml#L246
   # unlike services, no SSL support for pods
   - job_name: mcp-plain-pods
-      scheme: http
-      kubernetes_sd_configs:
-      - role: pod
-        namespaces:
-          names:
-            - {{ namespace }}
-      relabel_configs:
+    scheme: http
+    kubernetes_sd_configs:
+    - role: pod
+      namespaces:
+        names:
+          - {{ namespace }}
+    relabel_configs:
       - action: keep
         regex: \/.*
         source_labels:


### PR DESCRIPTION
How to verify:

- Provision this PR of the APB
- Clone the test app `https://github.com/aliok/node-app-with-prometheus-metrics.git`
- Switch to project running the metrics apb: `oc project foo`
- Deploy the test app: `oc new-app -f openshift-template.json`
- This will deploy the test app with **annotations on the service**.
- Delete the annotation `org.aerogear.metrics/plain_endpoint: /metrics` from the test app service
- Add the same annotation to the test app pod
- Check the pod logs: you should see requests coming at `/metrics`
- Scale the test app up (need to add the annotation to new pods manually) and make sure you see log entries as above