### PR TITLE
Reverting the change of playbooks' location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ICAgICAgIAo="
 
 
 
-COPY playbooks /opt/apb/project
+COPY playbooks /opt/apb/actions
 COPY roles /opt/ansible/roles
 COPY vars /opt/ansible/vars
 RUN chmod -R g=u /opt/{ansible,apb}


### PR DESCRIPTION
* previous change resolved the problem with warning about deprecation of playbooks location, see https://github.com/aerogearcatalog/metrics-apb/commit/5039e2865bbe9572970965db99724c463518706b
* local push and provision did work, also apb test passed successfully, however after the new image was build and pushed to dockerhub repo, it's not possible to provision the APB anymore (log from provision pod: `'provision' NOT IMPLEMENTED`)