### PR TITLE
Use upstream images in provision role again

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -89,13 +89,13 @@ plans:
       - name: custom_prometheus_image
         title: Prometheus container image
         description: The image to use for the Prometheus server (You shouldn't need to change this)
-        default: registry.access.redhat.com/openshift3/prometheus:v3.11
+        default: docker.io/openshift/origin-prometheus:v3.11
         type: string
         required: True
       - name: custom_grafana_image
         title: Grafana container image
         description: The image to use for the Grafana server (You shouldn't need to change this)
-        default: registry.access.redhat.com/openshift3/grafana:v3.11
+        default: docker.io/grafana/grafana:5.2.3
         type: string
         required: True
       - name: custom_api_server_image

--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -1,11 +1,11 @@
 # Prometheus Values
-default_prometheus_image: registry.access.redhat.com/openshift3/prometheus:v3.11
+default_prometheus_image: docker.io/openshift/origin-prometheus:v3.11
 prometheus_image: '{{ custom_prometheus_image | default(default_prometheus_image, true) }}'
 prometheus_port: 9090
 prometheus_proxy_port: 4180
 
 # Grafana values
-default_grafana_image: registry.access.redhat.com/openshift3/grafana:v3.11
+default_grafana_image: docker.io/grafana/grafana:5.2.3
 grafana_image: '{{ custom_grafana_image | default(default_grafana_image, true) }}'
 grafana_port: 3000
 grafana_proxy_port: 4181

--- a/roles/provision-metrics-apb/tasks/provision-grafana.yml
+++ b/roles/provision-metrics-apb/tasks/provision-grafana.yml
@@ -201,6 +201,15 @@
   set_fact:
     org_preferences: "{{org_preferences_response.json}}"
 
+- debug:
+    msg: "Registered var: {{ mobile_services_dashboard_search_response }}"
+
+- debug:
+    msg: "Registered var json: {{ mobile_services_dashboard_search_response.json }}"
+
+- debug:
+    msg: "Registered var json [0]: {{ mobile_services_dashboard_search_response.json[0] }}"
+
 - name: "Change home dashboard id to mobile-services dashboard id {{ mobile_services_dashboard_search_response.json[0]['id'] }}"
   set_fact:
     org_preferences: "{{ org_preferences | combine({'homeDashboardId': mobile_services_dashboard_search_response.json[0]['id']}) }}"


### PR DESCRIPTION
In commit 07a948327faa1a8a59ab76060a925259725ab856 I had moved to
using registry.access.redhat.com, since images there are publicly
accessible.

According to https://access.redhat.com/RegistryAuthentication, that
will eventually be decommissioned though, in favour of
registry.redhat.io, which will require a Red Hat account.

I'm changing back to using public registries now, so that if/when it
gets decommissioned, this provision role isn't broken.