### PR TITLE
AEROGEAR-8511 Remove sync graphs in mobile services dashboard and sho…

### DIFF
--- a/roles/provision-metrics-apb/files/mobile-services-dashboard.json
+++ b/roles/provision-metrics-apb/files/mobile-services-dashboard.json
@@ -297,7 +297,11 @@
               "min": null,
               "show": false
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -380,7 +384,11 @@
               "min": null,
               "show": false
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Keycloak",
@@ -397,10 +405,10 @@
       "id": 4,
       "panels": [
         {
-          "content": "# Data Synchronization\n\nSync mobile data synchronization framework allows Sync Apps to seamessly continue working when the network conection is lost, and allows them to recover when the network connection is restored.\n\nFind out more at [docs.aerogear.org](https://docs.aerogear.org/aerogear/latest/data_sync.html)!",
+          "content": "# Data Synchronization\n\nSync mobile data synchronization framework allows Sync Apps to seamessly continue working when the network conection is lost, and allows them to recover when the network connection is restored.\n\nOn the right side, you can find the data sync dashboards created per provisioned data sync application.\n\nFind out more at [docs.aerogear.org](https://docs.aerogear.org/aerogear/latest/data_sync.html)!",
           "gridPos": {
-            "h": 4,
-            "w": 14,
+            "h": 7,
+            "w": 11,
             "x": 0,
             "y": 2
           },
@@ -412,537 +420,26 @@
           "type": "text"
         },
         {
-          "cacheTimeout": null,
-          "colorBackground": true,
-          "colorValue": false,
-          "colors": [
-            "rgba(255, 255, 255, 0)",
-            "#7eb26d",
-            "rgba(255, 255, 255, 0)"
-          ],
-          "datasource": "Prometheus",
-          "description": "Number of currently provisioned Data Sync Server pods",
-          "format": "none",
-          "gauge": {
-            "maxValue": 0,
-            "minValue": null,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": false
-          },
+          "folderId": null,
           "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 14,
+            "h": 7,
+            "w": 13,
+            "x": 11,
             "y": 2
           },
-          "id": 71,
-          "interval": null,
+          "headings": false,
+          "id": 77,
+          "limit": 10,
           "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
+          "query": "",
+          "recent": false,
+          "search": true,
+          "starred": false,
+          "tags": [
+            "data-sync"
           ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "No",
-              "to": "null"
-            },
-            {
-              "from": "0",
-              "text": "Yes",
-              "to": "999999"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(up{service=\"data-sync-server\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "1",
-          "title": "Number of Pods",
-          "transparent": false,
-          "type": "singlestat",
-          "valueFontSize": "100%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "0",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "Prometheus",
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 4,
-            "x": 18,
-            "y": 2
-          },
-          "id": 10,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "avg(nodejs_version_info{service=\"data-sync-server\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "title": "Version",
-          "type": "singlestat",
-          "valueFontSize": "100%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "0.1.0",
-              "value": "1"
-            },
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "avg"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "Prometheus",
-          "decimals": 1,
-          "description": "Current memory usage of all Data Sync pods",
-          "format": "bytes",
-          "gauge": {
-            "maxValue": 2067000000,
-            "minValue": 0,
-            "show": true,
-            "thresholdLabels": false,
-            "thresholdMarkers": false
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 0,
-            "y": 6
-          },
-          "hideTimeOverride": true,
-          "id": 63,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(process_resident_memory_bytes{service=\"data-sync-server\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "refId": "A"
-            }
-          ],
-          "thresholds": "682e6, 1364e6",
-          "timeFrom": "5s",
-          "title": "Memory Usage",
-          "type": "singlestat",
-          "valueFontSize": "50%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "Prometheus",
-          "decimals": 1,
-          "description": "Current CPU usage",
-          "format": "percent",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": true,
-            "thresholdLabels": false,
-            "thresholdMarkers": false
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 5,
-            "x": 5,
-            "y": 6
-          },
-          "hideTimeOverride": true,
-          "id": 65,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(rate(process_cpu_user_seconds_total{service=\"data-sync-server\"}[30s]) * 100)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "refId": "A"
-            }
-          ],
-          "thresholds": "682e6, 1364e6",
-          "timeFrom": "5s",
-          "title": "CPU Usage",
-          "type": "singlestat",
-          "valueFontSize": "50%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "Prometheus",
-          "description": "Total number of resolved queries and mutations in time",
-          "fill": 2,
-          "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 10,
-            "y": 6
-          },
-          "hideTimeOverride": false,
-          "id": 73,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": 70,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(requests_resolved_total{operation_type=\"query\",service=\"data-sync-server\"})",
-              "format": "time_series",
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "Query",
-              "refId": "A"
-            },
-            {
-              "expr": "sum(requests_resolved_total{operation_type=\"mutation\",service=\"data-sync-server\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "Mutation",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Queries/Mutations Resolved",
-          "tooltip": {
-            "shared": false,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "none",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "Prometheus",
-          "description": "Server response time in milliseconds",
-          "fill": 2,
-          "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 16,
-            "y": 6
-          },
-          "hideTimeOverride": false,
-          "id": 69,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": 120,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "avg(server_response_ms_sum{request_type=\"POST\", service=\"data-sync-server\"} / server_response_ms_count{request_type=\"POST\", service=\"data-sync-server\"})",
-              "format": "time_series",
-              "instant": false,
-              "interval": "",
-              "intervalFactor": 1,
-              "legendFormat": "POST",
-              "refId": "A"
-            },
-            {
-              "expr": "avg(server_response_ms_sum{request_type=\"GET\", service=\"data-sync-server\"} / server_response_ms_count{request_type=\"GET\", service=\"data-sync-server\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "GET",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Server response time",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "ms",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
+          "title": "Data Sync Dashboards",
+          "type": "dashlist"
         }
       ],
       "title": "Sync",
@@ -964,7 +461,7 @@
             "h": 4,
             "w": 13,
             "x": 0,
-            "y": 14
+            "y": 3
           },
           "id": 27,
           "links": [
@@ -1003,7 +500,7 @@
             "h": 4,
             "w": 3,
             "x": 13,
-            "y": 14
+            "y": 3
           },
           "id": 43,
           "interval": null,
@@ -1086,7 +583,7 @@
             "h": 4,
             "w": 3,
             "x": 16,
-            "y": 14
+            "y": 3
           },
           "id": 42,
           "interval": null,
@@ -1168,7 +665,7 @@
             "h": 4,
             "w": 3,
             "x": 19,
-            "y": 14
+            "y": 3
           },
           "id": 41,
           "interval": null,
@@ -1230,6 +727,7 @@
         },
         {
           "aliasColors": {},
+          "breakPoint": "50%",
           "cacheTimeout": null,
           "combine": {
             "label": "Others",
@@ -1242,7 +740,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 18
+            "y": 7
           },
           "id": 33,
           "interval": null,
@@ -1275,6 +773,7 @@
         },
         {
           "aliasColors": {},
+          "breakPoint": "50%",
           "cacheTimeout": null,
           "combine": {
             "label": "Others",
@@ -1287,7 +786,7 @@
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 18
+            "y": 7
           },
           "id": 37,
           "interval": null,
@@ -1320,6 +819,7 @@
         },
         {
           "aliasColors": {},
+          "breakPoint": "50%",
           "cacheTimeout": null,
           "combine": {
             "label": "Others",
@@ -1332,7 +832,7 @@
             "h": 9,
             "w": 6,
             "x": 12,
-            "y": 18
+            "y": 7
           },
           "id": 39,
           "interval": null,
@@ -1365,6 +865,7 @@
         },
         {
           "aliasColors": {},
+          "breakPoint": "50%",
           "cacheTimeout": null,
           "combine": {
             "label": "Others",
@@ -1377,7 +878,7 @@
             "h": 9,
             "w": 6,
             "x": 18,
-            "y": 18
+            "y": 7
           },
           "id": 54,
           "interval": null,
@@ -1778,6 +1279,7 @@
         },
         {
           "aliasColors": {},
+          "breakPoint": "50%",
           "cacheTimeout": null,
           "combine": {
             "label": "Others",
@@ -1823,6 +1325,7 @@
         },
         {
           "aliasColors": {},
+          "breakPoint": "50%",
           "cacheTimeout": null,
           "combine": {
             "label": "Others",
@@ -1868,6 +1371,7 @@
         },
         {
           "aliasColors": {},
+          "breakPoint": "50%",
           "cacheTimeout": null,
           "combine": {
             "label": "Others",
@@ -1913,6 +1417,7 @@
         },
         {
           "aliasColors": {},
+          "breakPoint": "50%",
           "cacheTimeout": null,
           "combine": {
             "label": "Others",


### PR DESCRIPTION
…w the list of sync dashboards (they use a label)

See https://issues.jboss.org/browse/AEROGEAR-8511

Related to https://github.com/aerogearcatalog/sync-app-apb/pull/11 as some of the graphs in mobile services dashboard is moved to sync dashboard.

Verification: https://grafana-ggg.apps.aliok-64ea.openshiftworkshop.com/dashboard/db/mobile-services-3?orgId=1