### PR TITLE
Add keycloak-dashboard.json to Grafana dashboards if it's present in a project

### DIFF
--- a/roles/oc-patch-file-to-configmap/Readme.md
+++ b/roles/oc-patch-file-to-configmap/Readme.md
@@ -1,0 +1,26 @@
+# oc-patch-file-to-configmap-role
+
+The contents of this dir are a copy of the repo at
+https://github.com/aerogear/oc-patch-file-to-configmap-role at commit
+25d961b37d9c3ddc3fadc9544af785bd781c5bbd
+
+This is a basic Ansible role that can be used to add a JSON file to an existing Openshift Config Map. (using the `oc` CLI tool under the hood).
+
+### Motivation
+
+This role was created for use in the [AeroGear Catalog](https://github.com/organizations/aerogear) Ansible Playbook bundles, specifically to add Grafana Dashboard JSON files as part of a service provision.
+
+### Usage
+
+Inside your APB's `playbooks/provision.yml`:
+
+```yaml
+roles:
+  - role: oc-patch-file-to-configmap
+  file: "{{ lookup('file','/path/to/file.json') }}" # contents of the file
+  filename: "myfile.json" # name the filename will have inside the Config Map
+  configmap: "my-configmap"
+  namespace: "my-project"
+```
+
+You can also take a look at some of the APBs in the [AeroGear Catalog](https://github.com/organizations/aerogear) to see it in action.

--- a/roles/oc-patch-file-to-configmap/tasks/main.yml
+++ b/roles/oc-patch-file-to-configmap/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: Check to see if the specified Config Map exists
+  shell: oc get configmap {{ configmap }} -n {{ namespace }}
+  ignore_errors: yes
+  register: check_configmap
+
+- name: Print Warning Message about Config Map not Existing
+  debug:
+    msg: "Warning: Cannot add file {{ filename }} to Config Map {{ configmap }}. Config Map does not exist."
+  when: check_configmap.rc != 0
+
+- block:
+
+  - name: Create appropriate contents from template for 'oc patch' command
+    template:
+      src: oc-patch.json.j2
+      dest: /tmp/oc-patch.json
+
+  - name: Add file to the specified config map
+    shell: oc patch configmap {{ configmap }} -p {{ lookup('file', '/tmp/oc-patch.json') | quote }} -n {{ namespace }}
+    ignore_errors: yes
+    register: oc_patch_result
+
+  - name: Print Debug info about failed oc patch operation
+    debug:
+      var: oc_patch_result
+    when: oc_patch_result.rc != 0
+
+  when: check_configmap.rc == 0

--- a/roles/oc-patch-file-to-configmap/templates/oc-patch.json.j2
+++ b/roles/oc-patch-file-to-configmap/templates/oc-patch.json.j2
@@ -1,0 +1,1 @@
+{"data":{"{{ filename }}": {{ file_contents | to_json | to_json }}}}

--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -28,3 +28,6 @@ postgres_database: "aerogear_mobile_metrics"
 # OAuth Proxy values
 proxy_image: "registry.access.redhat.com/openshift3/oauth-proxy"
 proxy_version: "v3.11"
+
+# Keycloak values
+keycloak_dashboard_configmap_name: keycloak-dashboard.json

--- a/roles/provision-metrics-apb/tasks/provision-grafana.yml
+++ b/roles/provision-metrics-apb/tasks/provision-grafana.yml
@@ -26,6 +26,28 @@
       --from-file=mobile-app-security-dashboard.json={{ role_path }}/files/mobile-app-security-dashboard.json \
       -n '{{ namespace }}'
 
+- name: "Check if {{ keycloak_dashboard_configmap_name }} configmap exists in the namespace"
+  shell: "oc get configmap {{ keycloak_dashboard_configmap_name }} -n {{ namespace }} -o jsonpath='{.data.keycloak-dashboard\\.json}'"
+  register: get_keycloak_configmap_output
+  ignore_errors: yes
+
+- block:
+  - name: "Save {{ keycloak_dashboard_configmap_name }} content to variable"
+    set_fact: 
+      keycloak_dashboard_content: "{{ get_keycloak_configmap_output.stdout }}"
+
+  - include_role:
+      name: oc-patch-file-to-configmap
+    vars:
+      file_contents: "{{ keycloak_dashboard_content }}"
+      filename: "{{ keycloak_dashboard_configmap_name }}"
+      configmap: "grafana-dashboards-configmap"
+      namespace: "{{ namespace }}"
+
+  - name: "Delete configmap {{ keycloak_dashboard_configmap_name }} from the namespace since it's not needed anymore"
+    shell: "oc delete configmap {{ keycloak_dashboard_configmap_name }} -n {{ namespace }}"
+  when: get_keycloak_configmap_output.rc == 0
+
 - name: Grafana PVC
   k8s_v1_persistent_volume_claim:
     name: '{{ grafana_claim_name }}'


### PR DESCRIPTION
### Motivation
https://issues.jboss.org/browse/AEROGEAR-8317

### To verify
1. Spin up minishift and/or configure ASB on your cluster with `psturc` organisation and tag `AEROGEAR-8317`
1. Provision keycloak-apb
1. Provision metrics-apb
1. Verify `keycloak-dashboard.json` is present in `grafana-dashboards-configmap`
1. Go to Grafana and expand list of dashboards - `Keycloak metrics` dashboard should be present
