### PR TITLE
feat: add supported dashboards from ns to grafana

### DIFF
--- a/roles/provision-metrics-apb/defaults/main.yml
+++ b/roles/provision-metrics-apb/defaults/main.yml
@@ -28,6 +28,3 @@ postgres_database: "aerogear_mobile_metrics"
 # OAuth Proxy values
 proxy_image: "registry.access.redhat.com/openshift3/oauth-proxy"
 proxy_version: "v3.11"
-
-# Keycloak values
-keycloak_dashboard_configmap_name: keycloak-dashboard.json

--- a/roles/provision-metrics-apb/tasks/add-dashboards-to-grafana.yml
+++ b/roles/provision-metrics-apb/tasks/add-dashboards-to-grafana.yml
@@ -1,0 +1,18 @@
+- name: "Get {{ item }}'s configmap content"
+  shell: "oc get configmap {{ item }} -n {{ namespace }} -o jsonpath='{.data.{{ item | replace('.', '\\.') }} }'"
+  register: get_configmap_output
+
+- name: "Save {{ item }} content to variable"
+  set_fact:
+    dashboard_content: "{{ get_configmap_output.stdout }}"
+
+- include_role:
+    name: oc-patch-file-to-configmap
+  vars:
+    file_contents: "{{ dashboard_content }}"
+    filename: "{{ item }}"
+    configmap: "{{ grafana_dashboards_configmap_name }}"
+    namespace: "{{ namespace }}"
+
+- name: "Delete configmap {{ item }} from the namespace since it's not needed anymore"
+  shell: "oc delete configmap {{ item }} -n {{ namespace }}"

--- a/roles/provision-metrics-apb/tasks/provision-grafana.yml
+++ b/roles/provision-metrics-apb/tasks/provision-grafana.yml
@@ -26,27 +26,14 @@
       --from-file=mobile-app-security-dashboard.json={{ role_path }}/files/mobile-app-security-dashboard.json \
       -n '{{ namespace }}'
 
-- name: "Check if {{ keycloak_dashboard_configmap_name }} configmap exists in the namespace"
-  shell: "oc get configmap {{ keycloak_dashboard_configmap_name }} -n {{ namespace }} -o jsonpath='{.data.keycloak-dashboard\\.json}'"
-  register: get_keycloak_configmap_output
+- name: "Check if compatible configmap(s) with dashboards exist in the namespace"
+  shell: "oc get configmap -n {{ namespace }} | grep -oE 'sync-app.*.json|keycloak.*.json'"
+  register: get_dashboard_configmaps_output
   ignore_errors: yes
 
-- block:
-  - name: "Save {{ keycloak_dashboard_configmap_name }} content to variable"
-    set_fact: 
-      keycloak_dashboard_content: "{{ get_keycloak_configmap_output.stdout }}"
-
-  - include_role:
-      name: oc-patch-file-to-configmap
-    vars:
-      file_contents: "{{ keycloak_dashboard_content }}"
-      filename: "{{ keycloak_dashboard_configmap_name }}"
-      configmap: "grafana-dashboards-configmap"
-      namespace: "{{ namespace }}"
-
-  - name: "Delete configmap {{ keycloak_dashboard_configmap_name }} from the namespace since it's not needed anymore"
-    shell: "oc delete configmap {{ keycloak_dashboard_configmap_name }} -n {{ namespace }}"
-  when: get_keycloak_configmap_output.rc == 0
+- include_tasks: add-dashboards-to-grafana.yml
+  with_items: "{{ get_dashboard_configmaps_output.stdout_lines }}"
+  when: get_dashboard_configmaps_output.rc == 0
 
 - name: Grafana PVC
   k8s_v1_persistent_volume_claim:


### PR DESCRIPTION
### Motivation
https://issues.jboss.org/browse/AEROGEAR-8512

### Verification steps
1. Spin up minishift and/or configure ASB on your cluster with `psturc` organisation and tag `AEROGEAR-8512`
1. Provision keycloak-apb
1. Provision sync-app-apb with params:
    * docker image: `docker.io/psturc/voyager-server-example-metrics`
    * metrics endpoint: `metrics`
    * sync app port: `4000`
    * rest of params doesn't matter
1. Provision metrics-apb
1. Verify `keycloak-dashboard.json` and `sync-app-<your-app-name>-dashboard.json` are present in `grafana-dashboards-configmap`
1. Go to Grafana and expand list of dashboards - `IDM metrics` and Sync app dashboards should be present