### PR TITLE
fix: add missing tag for keycloak memory metrics query

### DIFF
--- a/roles/provision-metrics-apb/files/mobile-services-dashboard.json
+++ b/roles/provision-metrics-apb/files/mobile-services-dashboard.json
@@ -205,7 +205,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "max(jvm_memory_bytes_used{area=\"heap\"}) + max(jvm_memory_bytes_used{area=\"nonheap\"})",
+              "expr": "max(jvm_memory_bytes_used{area=\"heap\", kubernetes_name=\"keycloak\"}) + max(jvm_memory_bytes_used{area=\"nonheap\", kubernetes_name=\"keycloak\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "",


### PR DESCRIPTION
This is deploy here: https://master.uxreview-bcc8.openshiftworkshop.com/console/project/test-kc-customised/overview.

If you check the dashboard, keycloak has no memory usage, and if you check Prometheus, you will see there are metrics about UPS memory usage.